### PR TITLE
Fix phoneMasks for France and fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,14 @@ create a `react-native.config.js` file at the root of your react-native project 
     android: {},
   },
   assets: [
-    './node_modules/react-native-international-phone-number/assets/fonts',
+    './node_modules/react-native-international-phone-number/lib/assets/fonts',
   ],
  };
+```
+
+Then link the font to your native projects with:
+```bash
+npx react-native-asset
 ```
 
 - Using Expo:
@@ -125,7 +130,7 @@ create a `react-native.config.js` file at the root of your react-native project 
  ...
 
  useFonts({
-    'TwemojiMozilla': require('./node_modules/react-native-international-phone-number/assets/fonts/TwemojiMozilla.ttf'),
+    'TwemojiMozilla': require('./node_modules/react-native-international-phone-number/lib/assets/fonts/TwemojiMozilla.ttf'),
   });
 
  ...

--- a/lib/constants/countries.js
+++ b/lib/constants/countries.js
@@ -2082,7 +2082,7 @@ export const countries = [
       ua: 'Франція',
       zh: '法國',
     },
-    phoneMasks: ['### ### ###'],
+    phoneMasks: ['# ## ## ## ##', '## ## ## ## ##'],
   },
   {
     callingCode: '+241',


### PR DESCRIPTION
As related in this issue : https://github.com/AstrOOnauta/react-native-international-phone-number/issues/25

This pull request is indented to fix the phoneMasks for French numbers.

I also noticed a little issue in the README (missing `/lib` folder for linking assets), it's fixed too in the PR.