### PR TITLE
Fix Cambodia phoneMasks

### DIFF
--- a/lib/constants/countries.js
+++ b/lib/constants/countries.js
@@ -3255,7 +3255,7 @@ export const countries = [
       ua: 'Камбоджа',
       zh: '柬埔寨',
     },
-    phoneMasks: ['## ### ##'],
+    phoneMasks: ['## ### ###', '## ### ####'],
   },
   {
     callingCode: '+686',


### PR DESCRIPTION
Cambodia phone numbers can be (0)12 345 678 or (0)12 345 6789. https://en.wikipedia.org/wiki/Telephone_numbers_in_Cambodia