### PR TITLE
Correctly apply mask when autofilling number

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -114,9 +114,6 @@ const PhoneInput = forwardRef(
       },
     };
 
-    // Preprocess countries for efficient lookup
-    const countriesMap = new Map(countries.map(country => [country.callingCode.replace('+', ''), country]));
-
     function updateRef(phoneNumber, country) {
       if (ref) {
         ref.current = {
@@ -185,14 +182,16 @@ const PhoneInput = forwardRef(
 
   // Function to determine the country from the calling code
   function startsWithAnyCallingCode(value) {
-    const numberWithoutPlus = value.replace('+', '');
-    for (const [callingCode, country] of countriesMap.entries()) {
-      if (numberWithoutPlus.startsWith(callingCode) && numberWithoutPlus.length >= callingCode.length) {
+    for (const country of countries) {
+      const callingCodeWithoutPlus = country.callingCode.replace('+', '');
+      const numberWithoutPlus = value.replace('+', '');
+      // Check both the match and the length
+      if (numberWithoutPlus.startsWith(callingCodeWithoutPlus) && numberWithoutPlus.length >= callingCodeWithoutPlus.length) {
         return country;
       }
     }
     return false;
-  }
+  };
 
   function onChangeText(phoneNumber, callingCode) {
     const likelyPasted = prevInputLength === 0 && phoneNumber.length > 7;

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,8 @@ import {
   CountryButton,
 } from 'react-native-country-codes-picker';
 
+import { countries } from './constants/countries';
+
 import getInputMask from './utils/getInputMask';
 import getAllCountries from './utils/getAllCountries';
 import getCountriesByName from './utils/getCountriesByName';
@@ -70,6 +72,7 @@ const PhoneInput = forwardRef(
     const [defaultCca2, setDefaultCca2] = useState('');
     const [inputValue, setInputValue] = useState(null);
     const [countryValue, setCountryValue] = useState(null);
+    const [prevInputLength, setPrevInputLength] = useState(0);
 
     const textInputRef = useRef(null);
 
@@ -111,6 +114,9 @@ const PhoneInput = forwardRef(
       },
     };
 
+    // Preprocess countries for efficient lookup
+    const countriesMap = new Map(countries.map(country => [country.callingCode.replace('+', ''), country]));
+
     function updateRef(phoneNumber, country) {
       if (ref) {
         ref.current = {
@@ -133,13 +139,12 @@ const PhoneInput = forwardRef(
 
     function onSelect(country) {
       setShow(false);
-
       if (ref) {
         setInputValue('');
       } else {
         onChangePhoneNumber('');
       }
-
+      setPrevInputLength(0);
       if (onChangeSelectedCountry || ref) {
         const newValue = {
           name: country.name,
@@ -157,22 +162,62 @@ const PhoneInput = forwardRef(
       }
     }
 
-    function onChangeText(phoneNumber, callingCode) {
-      const res = getInputMask(
-        phoneNumber,
-        callingCode ? callingCode : countryValue?.callingCode,
-        countryValue?.cca2,
-        customMask ? customMask : null
-      );
+  // Helper function to update input value and reference
+  function updateInputValue(maskedInput, country) {
+    if (ref) {
+      setInputValue(maskedInput);
+      updateRef(maskedInput, country);
+    } else {
+      onChangePhoneNumber(maskedInput);
+    }
+  }
 
-      if (ref) {
-        setInputValue(res);
-        updateRef(res, countryValue);
-      } else {
-        onChangePhoneNumber(res);
+  // Helper function for handling masked input
+  function handleMaskedInput(phoneNumber, callingCode, countryCca2) {
+    const maskedInput = getInputMask(
+      phoneNumber,
+      callingCode || countryValue?.callingCode,
+      countryCca2 || countryValue?.cca2,
+      customMask || null
+    );
+    updateInputValue(maskedInput, countryValue);
+  }
+
+  // Function to determine the country from the calling code
+  function startsWithAnyCallingCode(value) {
+    const numberWithoutPlus = value.replace('+', '');
+    for (const [callingCode, country] of countriesMap.entries()) {
+      if (numberWithoutPlus.startsWith(callingCode) && numberWithoutPlus.length >= callingCode.length) {
+        return country;
       }
     }
+    return false;
+  }
 
+  function onChangeText(phoneNumber, callingCode) {
+    const likelyPasted = prevInputLength === 0 && phoneNumber.length > 7;
+  
+    if (likelyPasted) {
+      let assumedCountry = startsWithAnyCallingCode(phoneNumber);
+    
+      if (assumedCountry) {
+        if (ref) {
+          setCountryValue(assumedCountry);
+        } else {
+          onChangeSelectedCountry(assumedCountry);
+        }
+        handleMaskedInput(phoneNumber, assumedCountry.callingCode, assumedCountry.cca2);
+      } else if (phoneNumber.charAt(0) === '0') {
+        handleMaskedInput(phoneNumber, callingCode, countryValue?.cca2);
+      }
+    } else {
+      handleMaskedInput(phoneNumber, callingCode, countryValue?.cca2);
+    }
+  
+    setPrevInputLength(phoneNumber.length);
+  }
+    
+  
     useEffect(() => {
       if (!countryValue && !defaultCountry) {
         const defaultCountry = getCountryByCca2('BR');
@@ -367,7 +412,9 @@ const PhoneInput = forwardRef(
               }
               editable={!disabled}
               value={inputValue}
-              onChangeText={onChangeText}
+              onChange={({ nativeEvent }) => {
+                onChangeText(nativeEvent.text);
+              }}
               keyboardType="numeric"
               ref={textInputRef}
               {...rest}

--- a/lib/index.js
+++ b/lib/index.js
@@ -202,6 +202,7 @@ const PhoneInput = forwardRef(
       if (assumedCountry) {
         if (ref) {
           setCountryValue(assumedCountry);
+          updateRef('', assumedCountry);
         } else {
           onChangeSelectedCountry(assumedCountry);
         }
@@ -411,9 +412,7 @@ const PhoneInput = forwardRef(
               }
               editable={!disabled}
               value={inputValue}
-              onChange={({ nativeEvent }) => {
-                onChangeText(nativeEvent.text);
-              }}
+              onChangeText={onChangeText}
               keyboardType="numeric"
               ref={textInputRef}
               {...rest}

--- a/lib/utils/getInputMask.js
+++ b/lib/utils/getInputMask.js
@@ -59,8 +59,18 @@ export default function getInputMask(
   });
 
   let i = 0;
-  const newValue = phoneNumber.replace(/\D/g, '');
+  const callingCodeWithoutPlus = callingCode.replace('+', '');
+  let newValue = phoneNumber.replace(/\D/g, '');
+  
+  // Calculate the number of digit placeholders (#) in the matrix
+  const digitPlaceholders = matrix.replace(/[^#]/g, '').length;
 
+  // If newValue is longer than the mask, trim from the start only if the input starts with a calling code or a 0
+  if (newValue.length > digitPlaceholders && newValue.startsWith(callingCodeWithoutPlus) && newValue.charAt(0) === '0') {
+    const excessLength = newValue.length - digitPlaceholders;
+    newValue = newValue.substring(excessLength);
+  }
+  
   return matrix.replace(/(?!\+)./g, function (a) {
     return /[#\d]/.test(a) && i < newValue.length
       ? newValue.charAt(i++)

--- a/lib/utils/getInputMask.js
+++ b/lib/utils/getInputMask.js
@@ -66,7 +66,7 @@ export default function getInputMask(
   const digitPlaceholders = matrix.replace(/[^#]/g, '').length;
 
   // If newValue is longer than the mask, trim from the start only if the input starts with a calling code or a 0
-  if (newValue.length > digitPlaceholders && newValue.startsWith(callingCodeWithoutPlus) && newValue.charAt(0) === '0') {
+  if (newValue.length > digitPlaceholders && newValue.startsWith(callingCodeWithoutPlus) || newValue.charAt(0) === '0') {
     const excessLength = newValue.length - digitPlaceholders;
     newValue = newValue.substring(excessLength);
   }


### PR DESCRIPTION
This PR fixes the autofilling of phone numbers (like iOS suggested fill at the top of the keyboard) by trimming the extra characters from the start of the input if it meets certain conditions. 

This was a major issue before and essentially made autofilling impossible with this library. 

The conditons are 

- Input starts with a country code 
- Input starts with a 0 

Making this change means that instead of trimming the end of the number (current behaviour) and then the user needing to delete the autofilled data and manually enter their number leaving off the country code or 0 it will be automatically trimmed and therefore viable.

By checking for these conditions we preserve the excellent functionality of the library where the user cannot enter more characters than required for their countries mask. 