### PR TITLE
Fixed phone mask for Nepal

### DIFF
--- a/lib/constants/countries.js
+++ b/lib/constants/countries.js
@@ -4698,7 +4698,7 @@ export const countries = [
       ua: 'Непал',
       zh: '尼尼泊爾',
     },
-    phoneMasks: ['## ### ###'],
+    phoneMasks: ['##### #####'],
   },
   {
     callingCode: '+674',


### PR DESCRIPTION
Nepalese phone numbers contain 10 digits after the country code.
So I changed the phone mask from ['## ### ###'] to ['##### #####']