### PR TITLE
RTL Support - swap elements

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,6 +64,7 @@ const PhoneInput = forwardRef(
       modalSearchInputSelectionColor,
       modalNotFoundCountryMessage,
       customCaret,
+      rtl,
       ...rest
     },
     ref
@@ -111,6 +112,7 @@ const PhoneInput = forwardRef(
         modalSearchInputSelectionColor,
         modalNotFoundCountryMessage,
         customCaret,
+        rtl,
         ...rest,
       },
     };
@@ -319,6 +321,98 @@ const PhoneInput = forwardRef(
         "Error: Don't use the useRef hook combined with the useState hook to manage the phoneNumber and selectedCountry values. Instead, choose to use just one of them (useRef or useState)."
       );
     } else {
+
+      // Create a separate constant for each part of the component 
+      const touchableStart =
+      <Text style={getFlagStyle(phoneInputStyles?.flag)}>
+        {countryValue?.flag}
+      </Text>
+      {customCaret || (
+        <View style={phoneInputStyles?.caret}>
+          <View
+            style={{
+              flexDirection: 'row',
+              justifyContent: 'center',
+              paddingTop: 4,
+            }}
+          >
+            <View
+              style={getCaretStyle(
+                theme,
+                phoneInputStyles?.caret
+              )}
+            />
+          </View>
+        </View>
+      )};
+
+      const touchableMiddle =
+      <View
+        style={getDividerStyle(
+          theme,
+          phoneInputStyles?.divider
+        )}
+      />;
+
+      const touchableEnd =
+      <Text
+        style={getFlagTextStyle(
+          theme,
+          phoneInputStyles?.callingCode
+        )}
+      >
+        {countryValue?.callingCode}
+      </Text>;
+
+      const touchablePart =
+      <TouchableOpacity
+        activeOpacity={disabled || modalDisabled ? 1 : 0.6}
+        onPress={() =>
+          disabled || modalDisabled ? null : setShow(true)
+        }
+        style={getFlagContainerStyle(
+          theme,
+          phoneInputStyles?.flagContainer
+        )}
+      >
+        {/* LTR Display */}
+        {!rtl && touchableEnd}
+        {!rtl && touchableMiddle}
+        {!rtl && touchableStart}
+
+        {/* RTL Display */}
+        {rtl && touchableStart}
+        {rtl && touchableMiddle}
+        {rtl && touchableEnd}
+      </TouchableOpacity>;
+
+      const inputPart =
+      <TextInput
+        style={getInputStyle(theme, phoneInputStyles?.input)}
+        placeholder={
+          placeholder === '' || placeholder
+            ? placeholder
+            : getPhoneNumberInputPlaceholder(language || 'en')
+        }
+        placeholderTextColor={
+          placeholderTextColor ||
+          (theme === 'dark' ? '#CCCCCC' : '#AAAAAA')
+        }
+        selectionColor={
+          selectionColor ||
+          (theme === 'dark'
+            ? 'rgba(255,255,255, .4)'
+            : 'rgba(0 ,0 ,0 , .4)')
+        }
+        editable={!disabled}
+        value={inputValue}
+        onChangeText={onChangeText}
+        keyboardType="numeric"
+        ref={textInputRef}
+        {...rest}
+      />;
+
+      
       return (
         <>
           <View
@@ -328,76 +422,13 @@ const PhoneInput = forwardRef(
               disabled
             )}
           >
-            <TouchableOpacity
-              activeOpacity={disabled || modalDisabled ? 1 : 0.6}
-              onPress={() =>
-                disabled || modalDisabled ? null : setShow(true)
-              }
-              style={getFlagContainerStyle(
-                theme,
-                phoneInputStyles?.flagContainer
-              )}
-            >
-              <Text style={getFlagStyle(phoneInputStyles?.flag)}>
-                {countryValue?.flag}
-              </Text>
-              {customCaret || (
-                <View style={phoneInputStyles?.caret}>
-                  <View
-                    style={{
-                      flexDirection: 'row',
-                      justifyContent: 'center',
-                      paddingTop: 4,
-                    }}
-                  >
-                    <View
-                      style={getCaretStyle(
-                        theme,
-                        phoneInputStyles?.caret
-                      )}
-                    />
-                  </View>
-                </View>
-              )}
-              <View
-                style={getDividerStyle(
-                  theme,
-                  phoneInputStyles?.divider
-                )}
-              />
-              <Text
-                style={getFlagTextStyle(
-                  theme,
-                  phoneInputStyles?.callingCode
-                )}
-              >
-                {countryValue?.callingCode}
-              </Text>
-            </TouchableOpacity>
-            <TextInput
-              style={getInputStyle(theme, phoneInputStyles?.input)}
-              placeholder={
-                placeholder === '' || placeholder
-                  ? placeholder
-                  : getPhoneNumberInputPlaceholder(language || 'en')
-              }
-              placeholderTextColor={
-                placeholderTextColor ||
-                (theme === 'dark' ? '#CCCCCC' : '#AAAAAA')
-              }
-              selectionColor={
-                selectionColor ||
-                (theme === 'dark'
-                  ? 'rgba(255,255,255, .4)'
-                  : 'rgba(0 ,0 ,0 , .4)')
-              }
-              editable={!disabled}
-              value={inputValue}
-              onChangeText={onChangeText}
-              keyboardType="numeric"
-              ref={textInputRef}
-              {...rest}
-            />
+            {/* LTR Display */}
+            {!rtl && touchablePart}
+            {!rtl && inputPart}
+
+            {/* RTL Display */}
+            {rtl && inputPart}
+            {rtl && touchablePart}
           </View>
           {!disabled && !modalDisabled && show ? (
             <CountryPicker

--- a/lib/index.js
+++ b/lib/index.js
@@ -376,14 +376,14 @@ const PhoneInput = forwardRef(
         )}
       >
         {/* LTR Display */}
-        {!rtl && touchableEnd}
-        {!rtl && touchableMiddle}
         {!rtl && touchableStart}
+        {!rtl && touchableMiddle}
+        {!rtl && touchableEnd}
 
         {/* RTL Display */}
-        {rtl && touchableStart}
-        {rtl && touchableMiddle}
         {rtl && touchableEnd}
+        {rtl && touchableMiddle}
+        {rtl && touchableStart}
       </TouchableOpacity>;
 
       const inputPart =


### PR DESCRIPTION
This fixes #68 
Phone numbers (like any number) should be written LTR (Left-to-Right) regardless of the language.

In the component of this library, in RTL (Right-to-Left) mode, the country code (and flag) are displayed on the right side and the phone number on the left side of the screen. 

Based on the value of an RTL property, the order of the components is changed.

Obviously, the property "rtl" needs to be added to the props list in the readme file. 