### PR TITLE
added Section titles in carret when popularCountries are present.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,7 @@ import {
   getFlagTextStyle,
   getInputStyle,
 } from './utils/getStyles';
+import styles from "./styles";
 
 const PhoneInput = forwardRef(
   (
@@ -59,6 +60,8 @@ const PhoneInput = forwardRef(
       showOnly,
       excludedCountries,
       popularCountries,
+      popularCountriesSectionTitle,
+      restOfCountriesSectionTitle,
       modalSearchInputPlaceholder,
       modalSearchInputPlaceholderTextColor,
       modalSearchInputSelectionColor,
@@ -433,21 +436,31 @@ const PhoneInput = forwardRef(
               excludedCountries={excludedCountries}
               popularCountries={popularCountries}
               ListHeaderComponent={({ countries, lang, onPress }) => {
-                return countries.map((country, index) => {
-                  return (
-                    <CountryButton
-                      key={index}
-                      item={country}
-                      name={country?.name?.[lang || 'en']}
-                      onPress={() => onPress(country)}
-                      style={getCountryPickerStyle(
-                        theme,
-                        modalHeight,
-                        modalStyles
+                return   (
+                    <View>
+                      {popularCountriesSectionTitle &&(
+                      <Text>{popularCountriesSectionTitle}</Text>
                       )}
-                    />
-                  );
-                });
+                      {countries.map((country, index) => {
+                        return (
+                            <CountryButton
+                                key={index}
+                                item={country}
+                                name={country?.name?.[lang || 'en']}
+                                onPress={() => onPress(country)}
+                                style={getCountryPickerStyle(
+                                    theme,
+                                    modalHeight,
+                                    modalStyles
+                                )}
+                            />
+                        );
+                      })}
+                      {restOfCountriesSectionTitle &&(
+                      <Text style={styles.sectionTitle}>{restOfCountriesSectionTitle}</Text>
+                      )}
+                    </View>
+                )
               }}
             />
           ) : null}

--- a/lib/interfaces/phoneInputProps.ts
+++ b/lib/interfaces/phoneInputProps.ts
@@ -26,6 +26,8 @@ interface BasePhoneInput extends TextInputProps {
   showOnly?: Array<ICountryCca2>;
   excludedCountries?: Array<ICountryCca2>;
   popularCountries?: Array<ICountryCca2>;
+  popularCountriesSectionTitle?:string,
+  restOfCountriesSectionTitle?:string,
   modalSearchInputPlaceholder?: string;
   modalSearchInputPlaceholderTextColor?: string;
   modalSearchInputSelectionColor?: string;

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -112,7 +112,10 @@ const styles = StyleSheet.create({
     ...inputBase,
     color: '#F3F3F3',
   },
-
+  sectionTitle:{
+   marginTop: 10,
+   marginBottom: 10,
+  },
   lightCountryPicker: {
     modal: {
       backgroundColor: '#FFFFFF',


### PR DESCRIPTION
## Improving UX when `popularCountries` are selected. 
If we pass a `popularCountries` array, these countries are displayed on the top of the rest of the list without any divider or sign, and the user might not understand or get confused by the sorting of the list. 
That's why I've added section titles. 
<img src="https://github.com/AstrOOnauta/react-native-international-phone-number/assets/45794572/8a879c9c-7dc1-4bb3-a149-1ea5c314afda" alt="srceenshot" width="350"/>