### PR TITLE
fix: South Korea phone mask

### DIFF
--- a/lib/constants/countries.js
+++ b/lib/constants/countries.js
@@ -3637,7 +3637,7 @@ export const countries = [
       zh: '韓國',
       tr: 'Kore Cumhuriyeti',
     },
-    phoneMasks: ['## ### ####'],
+    phoneMasks: ['### #### ####'],
   },
   {
     callingCode: '+965',


### PR DESCRIPTION
Hello,

This repository is truly amazing. 👍

I updated the South Korea mask format from ‘## ### ####’ to ‘### #### ####’.