### PR TITLE
Update countries.js ,Benin's official number is 10 instead of 8 since…

### DIFF
--- a/lib/constants/countries.js
+++ b/lib/constants/countries.js
@@ -783,7 +783,7 @@ export const countries = [
       zh: '貝寧',
       tr: 'Benin',
     },
-    phoneMasks: ['## ## ####'],
+    phoneMasks: ['### ## ####'],
   },
   {
     callingCode: '+590',


### PR DESCRIPTION
… 2024.

Benin's official number is 10 instead of 8 since 2024.