### PR TITLE
feat: added testIDs on CountryPicker, TextInput and FlagSelection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -421,7 +421,6 @@ const PhoneInput = forwardRef(
           onChangeText={onChangeText}
           keyboardType="numeric"
           ref={textInputRef}
-          testID={`${testID}-input`}
           {...rest}
         />
       );

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,6 +69,7 @@ const PhoneInput = forwardRef(
       customCaret,
       rtl,
       allowZeroAfterCallingCode,
+      testID,
       ...rest
     },
     ref
@@ -120,6 +121,7 @@ const PhoneInput = forwardRef(
         customCaret,
         rtl,
         allowZeroAfterCallingCode,
+        testID,
         ...rest,
       },
     };
@@ -332,7 +334,7 @@ const PhoneInput = forwardRef(
       // Create a separate constant for each part of the component
       const touchableStart = (
         <>
-          <Text style={getFlagStyle(phoneInputStyles?.flag)}>
+          <Text testID={`${testID}-flag`} style={getFlagStyle(phoneInputStyles?.flag)}>
             {countryValue?.flag}
           </Text>
           {customCaret || (
@@ -419,6 +421,7 @@ const PhoneInput = forwardRef(
           onChangeText={onChangeText}
           keyboardType="numeric"
           ref={textInputRef}
+          testID={`${testID}-input`}
           {...rest}
         />
       );
@@ -473,6 +476,7 @@ const PhoneInput = forwardRef(
               showOnly={showOnly}
               excludedCountries={excludedCountries}
               popularCountries={popularCountries}
+              testID={testID}
               ListHeaderComponent={({ countries, lang, onPress }) => {
                 return (
                   <View>


### PR DESCRIPTION
# Add testIDs for component testing

## Description
This PR add testID to key elements of the PhoneInput component to facilitate testing. The following testID was added:

- Flag/Country selector: `${testID}-flag`
- Test id on CountryPicker

## Example Usage
```javascript
// Assuming PhoneInput has testID="phone-number"
const flag = getByTestId('phone-number-flag');
```

## Changes Made
- Added testID to the flag/country selector Text component

## Testing
The testID can be used with testing libraries like @testing-library/react-native or Maestro to find and interact with these elements in tests.
