### PR TITLE
Fix navigator is not defined

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -75,7 +75,7 @@ const styles = StyleSheet.create({
     marginRight: 6,
     fontFamily:
       Platform.OS === 'web'
-        ? navigator?.userAgent?.includes('Win')
+        ? typeof navigator !== 'undefined' && navigator?.userAgent?.includes('Win')
           ? 'TwemojiMozilla'
           : 'System'
         : 'System',

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -146,7 +146,7 @@ const styles = StyleSheet.create({
       fontSize: 20,
       fontFamily:
         Platform.OS === 'web'
-          ? navigator?.userAgent?.includes('Win')
+          ? typeof navigator !== 'undefined' && navigator?.userAgent?.includes('Win')
             ? 'TwemojiMozilla'
             : 'System'
           : 'System',
@@ -187,7 +187,7 @@ const styles = StyleSheet.create({
       fontSize: 20,
       fontFamily:
         Platform.OS === 'web'
-          ? navigator?.userAgent?.includes('Win')
+          ? typeof navigator !== 'undefined' && navigator?.userAgent?.includes('Win')
             ? 'TwemojiMozilla'
             : 'System'
           : 'System',


### PR DESCRIPTION
When bundling with output set to "static" metro throws error navigator is not defined (at least on Mac), mentioned in issue #90 