### PR TITLE
Fix Typescript error (unused import)

### DIFF
--- a/lib/interfaces/phoneInputProps.ts
+++ b/lib/interfaces/phoneInputProps.ts
@@ -1,4 +1,4 @@
-import React, { Ref, ReactNode } from 'react';
+import { Ref, ReactNode } from 'react';
 import { TextInputProps } from 'react-native';
 
 import { ICountry } from './country';


### PR DESCRIPTION
React is imported in `phoneInputProps` but not used, resulting in a TS error.

`node_modules/react-native-international-phone-number/lib/interfaces/phoneInputProps.ts(1,8): error TS6133: 'React' is declared but its value is never read.`

This PR is to remove the unused import.