### PR TITLE
fix: resolve input field delay after updating to Expo SDK 52

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -431,7 +431,7 @@ const PhoneInput = forwardRef(
           editable={!disabled}
           value={inputValue}
           onChangeText={onChangeText}
-          keyboardType="numeric"
+          keyboardType="number-pad"
           ref={textInputRef}
           {...rest}
         />


### PR DESCRIPTION
I've resolved the issue related to the delay bug affecting some android devices after upgrading to Expo 52 or the new React Native Architecture. 

I just switched to `number-pad` instead of the `numeric` keyboard type. 