### PR TITLE
styles: set input height to 100%

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -45,6 +45,7 @@ const flagTextBase = {
 const inputBase = {
   flex: 1,
   width: '100%',
+  height: '100%',
   paddingVertical: 8,
   paddingHorizontal: 16,
   fontSize: 16,


### PR DESCRIPTION
Before:
<img width="471" height="80" alt="image" src="https://github.com/user-attachments/assets/3af819e4-154c-416a-ab06-bcdf76e74930" />
After:
<img width="471" height="80" alt="image" src="https://github.com/user-attachments/assets/b629b49f-d8e8-4072-bd4e-e5c5662ee9a8" />

Ideally, you'd set the border radius as well on the two corners opposite from the country selector:
<img width="471" height="80" alt="image" src="https://github.com/user-attachments/assets/bb1431c9-bcbe-46c7-8682-66dfb142f3cf" />
However, that gets a bit tricky with rtl:
<img width="471" height="80" alt="image" src="https://github.com/user-attachments/assets/cc6a935a-fbda-4963-8442-29ed02917f9f" />

So for now, I just PRed the easy fix, and set the border radius in our app (since we don't use RTL, we don't have to worry about handling it properly).