### PR TITLE
fix: handle trouble when Metadata didn't have country

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -282,54 +282,62 @@ const PhoneInput = forwardRef(
     }
 
     function formatPhoneNumber(phoneNumber, callingCode) {
-      let formattedNumber = '';
+      try {
+        let formattedNumber = '';
 
-      const metadata = new Metadata();
-      metadata.selectNumberingPlan(countryValue?.cca2);
+        const metadata = new Metadata();
+        metadata.selectNumberingPlan(countryValue?.cca2);
 
-      const possibleLengths = countryValue
-        ? metadata.possibleLengths()
-        : [];
+        const possibleLengths = countryValue
+          ? metadata.possibleLengths()
+          : [];
 
-      let validCallingCode = callingCode
-        ? callingCode
-        : countryValue?.idd?.root;
+        let validCallingCode = callingCode
+          ? callingCode
+          : countryValue?.idd?.root;
 
-      const res = formatIncompletePhoneNumber(
-        `${validCallingCode}${phoneNumber}`
-      );
+        const res = formatIncompletePhoneNumber(
+          `${validCallingCode}${phoneNumber}`
+        );
 
-      formattedNumber = res;
+        formattedNumber = res;
 
-      if (res.startsWith(0)) {
-        formattedNumber = parsePhoneNumber(res)?.formatNational();
-      } else {
-        if (
-          validCallingCode &&
-          res &&
-          res.startsWith(validCallingCode)
-        ) {
-          formattedNumber = res
-            .substring(validCallingCode.length)
-            .trim();
+        if (res.startsWith(0)) {
+          formattedNumber = parsePhoneNumber(res)?.formatNational();
+        } else {
+          if (
+            validCallingCode &&
+            res &&
+            res.startsWith(validCallingCode)
+          ) {
+            formattedNumber = res
+              .substring(validCallingCode.length)
+              .trim();
+          }
         }
-      }
 
-      const possibleLength = formattedNumber.startsWith(0)
-        ? possibleLengths.slice(-1)[0] + 1
-        : possibleLengths.slice(-1)[0];
+        const possibleLength = formattedNumber.startsWith(0)
+          ? possibleLengths.slice(-1)[0] + 1
+          : possibleLengths.slice(-1)[0];
 
-      if (
-        formattedNumber?.replace(/\D/g, '')?.length > possibleLength
-      ) {
-        return;
-      }
+        if (
+          formattedNumber?.replace(/\D/g, '')?.length > possibleLength
+        ) {
+          return;
+        }
 
-      setInputValue(formattedNumber);
-      if (onChangePhoneNumber) {
-        onChangePhoneNumber(formattedNumber);
+        setInputValue(formattedNumber);
+        if (onChangePhoneNumber) {
+          onChangePhoneNumber(formattedNumber);
+        }
+        updateRef(formattedNumber, countryValue);
+      } catch  {
+        setInputValue(phoneNumber);
+        if (onChangePhoneNumber) {
+          onChangePhoneNumber(phoneNumber);
+        }
+        updateRef(phoneNumber, countryValue);
       }
-      updateRef(formattedNumber, countryValue);
     }
 
     function onChangeText(phoneNumber, callingCode) {


### PR DESCRIPTION
My application crash when user choose `United States Minor Outlying Islands`

This happens when the user selects a country that is not in the Metadata.

This is small fix for function what response for generate formatted phone number.