### PR TITLE
For showing suffix dial codes of country

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,6 +61,7 @@ const PhoneInput = forwardRef(
       defaultValue,
       onChangePhoneNumber,
       selectedCountry,
+      showDialCodeSuffix ,
       onChangeSelectedCountry,
       customMask,
       visibleCountries,
@@ -463,7 +464,7 @@ const PhoneInput = forwardRef(
           )}
           allowFontScaling={allowFontScaling}
         >
-          {countryValue?.idd?.root}
+          {showDialCodeSuffix ? (countryValue?.idd?.root) : (countryValue?.idd?.suffixes?.[0] ?? '')}
         </Text>
       );
 

--- a/lib/interfaces/phoneInputProps.ts
+++ b/lib/interfaces/phoneInputProps.ts
@@ -59,6 +59,7 @@ interface BasePhoneInput extends TextInputProps {
   ) => React.ReactElement | null | undefined;
   showModalAlphabetFilter?: boolean;
   showModalSearchInput?: boolean;
+  showDialCodeSuffix ?: boolean;
   showModalCloseButton?: boolean;
   showModalScrollIndicator?: boolean;
   accessibilityLabelPhoneInput?: string;


### PR DESCRIPTION
I got some trouble getting suffix country codes, so I made use of a single prop called 'showDialCodeSuffix' for ease in show case of full country code in phone input. 
example (before):-
Trinidad and Tobago - '+1' (which was actually showed).
example (now):-
Trinidad and Tobago - '+1868' (which is actually the country code).

I hope this help well

Thank you.